### PR TITLE
Gunicorn issue73

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,36 @@ Ah crud need to reinstall python from source with --enabled-shared? This error c
 # sudo a2enmod wsgi <TBD is this really needed?>
 ```
 
+
+### Install Gunicorn
+
+[*Gunicorn*](http://gunicorn.org/) is a lightweight Python-based web server that can be used in place of the Apache server.
+It should perform better than Apache.  We have observed several-second delays with Apache when handling requests.
+
+```sh
+sudo pip install gunicorn
+```
+
+#### Make Gunicorn run at boot
+TO DO:  add instructions
+
+#### Stop Apache and start Gunicorn
+
+First stop the Apache service if it is running, then
+start Gunicorn and have it listen on the interface specified by <ip addr> (the server's IP address) port 80.
+
+```sh
+sudo service apache2 stop
+cd /opt/designchallenge2016/brata.masterserver/workspace/ms
+sudo gunicorn -b <ip addr>:80 --workers=3 ms.wsgi
+```
+
+#### Serving static files with Gunicorn
+
+Gunicorn can't serve the static files for our Django apps.
+Django can be configured to serve them up, or we can set up [*Nginx*](http://nginx.org/).
+
+
 ### Install PostgreSQL
 ```sh
 sudo apt-get install postgresql-9.1

--- a/workspace/ms/ms/settings.py
+++ b/workspace/ms/ms/settings.py
@@ -35,7 +35,7 @@ SECRET_KEY = '-4@1rw9sp&emici+=!_h51y-&0wfs1n3mmd@*o4a^*_7(m^kxe'
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
-ALLOWED_HOSTS = ['127.0.0.1']
+ALLOWED_HOSTS = ['127.0.0.1', 'ms01']
 
 
 # Application definition

--- a/workspace/ms/ms/urls.py
+++ b/workspace/ms/ms/urls.py
@@ -15,6 +15,8 @@ Including another URLconf
 """
 from django.conf.urls import include, url
 from django.contrib import admin
+import django.views.static
+from .settings import STATIC_ROOT
 
 from piservice import urls as piservice_urls
 from dbkeeper import urls as dbkeeper_urls
@@ -28,4 +30,9 @@ urlpatterns = [
     url(r'^dbkeeper/', include(dbkeeper_urls)),
     url(r'^hsdc/', include(dbkeeper_urls)), # alias for dbkeeper for student test pages
     url(r'^scoreboard/', include(scoreboard_urls)),
+    url(r'^$', include(dbkeeper_urls)),
+    
+    # Have Django serve up the static files for Gunicorn
+    # If we don't do this we need to serve them with Nginx
+    url(r'^static/(?P<path>.*)$', django.views.static.serve, {'document_root': STATIC_ROOT, 'show_indexes':True}),
 ]


### PR DESCRIPTION
Make modifications to run Gunicorn in place of Apache2.  The project is modified to serve static files through Django instead of having them served by the web server, because Gunicorn can't do that.  However, everything still works in Apache, too.
