### PR TITLE
Add reverse measurement checkbox to Return Challenge test page

### DIFF
--- a/workspace/ms/dbkeeper/forms.py
+++ b/workspace/ms/dbkeeper/forms.py
@@ -397,5 +397,6 @@ class ReturnTestForm(forms.Form):
     value4 = forms.CharField(label="4 =", max_length=2, initial="00", validators=[twoDigitValidator])
     value5 = forms.CharField(label="5 =", max_length=2, initial="00", validators=[twoDigitValidator])
     value6 = forms.CharField(label="6 =", max_length=2, initial="00", validators=[twoDigitValidator])
-    params = forms.CharField(max_length=50, widget=forms.HiddenInput())
-    school = forms.CharField(max_length=50, widget=forms.HiddenInput())
+    params = forms.CharField(max_length=200, widget=forms.HiddenInput(), required=False)
+    school = forms.CharField(max_length=100, widget=forms.HiddenInput(), required=False)
+    reverse = forms.BooleanField(label="Measured in reverse direction", required=False, initial=False)

--- a/workspace/ms/dbkeeper/templates/dbkeeper/regtest.html
+++ b/workspace/ms/dbkeeper/templates/dbkeeper/regtest.html
@@ -21,9 +21,9 @@
             <td style="text-align: left;">{{ team.name }}</td>
             <td style="text-align: left;">
              <a href="../regtest_team/{{team.pass_code}}/">Reg QRs</a></td>
-            <!--<td style="text-align: left;">
+            <td style="text-align: left;">
              <a href="../navtest_team/{{team.pass_code}}/{{team.points.0.0}}/{{team.points.0.1}}/{{team.points.1.0}}/{{team.points.1.1}}/{{team.points.2.0}}/{{team.points.2.1}}/{{team.points.3.0}}/{{team.points.3.1}}/{{team.organization}}/">Map Points</a></td>
-            -->
+            
           <td><a href="{{ dock_test_host }}/dock">Dock Sim Evaluator</a></td>
           <!--<td style="text-align: left;">
            <a href="../docktest_team/{{team.pass_code}}/">Dock QRs</a></td>-->

--- a/workspace/ms/dbkeeper/templates/dbkeeper/returntest_team.html
+++ b/workspace/ms/dbkeeper/templates/dbkeeper/returntest_team.html
@@ -39,6 +39,11 @@ tr.inputRow td {
   text-align: right;
   padding-right: 1em;
 }
+tr.checkRow td {
+  text-align: center;
+  font-size: 14pt;
+  padding-top: 2em;
+}
 .submitRow td {
   text-align: center;
 }
@@ -86,6 +91,9 @@ div.table {
             <td class="numfield {% if form.value4.errors %}invalid{% endif %}">{{ form.value4.label_tag }}{{ form.value4 }}</td>
             <td class="numfield {% if form.value5.errors %}invalid{% endif %}">{{ form.value5.label_tag }}{{ form.value5 }}</td>
             <td class="numfield {% if form.value6.errors %}invalid{% endif %}">{{ form.value6.label_tag }}{{ form.value6 }}</td>
+          </tr>
+          <tr class="checkRow">
+            <td colspan="6">{{ form.reverse.label_tag }}{{ form.reverse }}</td>
           </tr>
           <tr class="submitRow">
             <td colspan="6"><input type="submit" value="{{ submit }}" /></td>

--- a/workspace/ms/dbkeeper/views.py
+++ b/workspace/ms/dbkeeper/views.py
@@ -163,7 +163,7 @@ class ReturnTestTeam(View):
         params = json.loads(jparams)
         
         # Squirrel away values in hidden fields so we can get them back in POST
-        self.context["form"].fields["params"].initial = ",".join(params[schoolName])
+        self.context["form"].fields["params"].initial = json.dumps(params[schoolName])
         self.context["form"].fields["school"].initial = schoolName
         return render(request, "dbkeeper/returntest_team.html", self.context)
     
@@ -180,7 +180,9 @@ class ReturnTestTeam(View):
                        form.cleaned_data["value5"],
                        form.cleaned_data["value6"],
                      ]
-            params = form.cleaned_data["params"].split(",")
+            reverse = form.cleaned_data["reverse"]
+            params = json.loads(form.cleaned_data["params"])[1 if reverse else 0]
+
             match = reduce(operator.__and__, [a==b for a,b in zip(values, params)])
             if match:
                 self.context["answer"] = "Correct!"


### PR DESCRIPTION
This requires the format of the **RETURN_TEST_DATA** to be modified to hold both forward and reverse measurement values.  The `MS_Settings.xlsx` has also been updated to reflect the change.
